### PR TITLE
Direct version.txt download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ICON		:=	icon.jpg
 ARCH	:=	-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
-			$(ARCH) $(DEFINES)
+			$(ARCH) $(DEFINES) `curl-config --cflags`
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__
 
@@ -62,7 +62,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lnx
+LIBS	:= -lnx `curl-config --libs`
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A small console application that checks a Switch's installed contents against a provided versionlist for newer updates, and then writes the titles with newer updates and the latest version to sdmc:/Available-Updates.txt.
 
 ## Usage
-- Grab the latest versions.txt available from the [titledb Repository](https://github.com/blawar/titledb/blob/master/versions.txt), and save it in the same directory as NX-Update-Checker.nro
+- In case of no internet connection, grab the latest versions.txt available from the [titledb Repository](https://github.com/blawar/titledb/blob/master/versions.txt), and save it in the same directory as NX-Update-Checker.nro
 - Run the nro with your favorite variation of the HBMenu
 - Watch the pretty text move across the screen
 - Profit(?)

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ A small console application that checks a Switch's installed contents against a 
 - Watch the pretty text move across the screen
 - Profit(?)
 
-
-## Notice
+## Additional Information
 This app was specifically re-written to parse the versions.txt posted in the [titledb Repository](https://github.com/blawar/titledb), if you provide a versions.txt with even a slightly different format it is likely this application will not parse it correctly.
 
+As of writing (2020/06/09) binaries are built using switch-curl 7.69.1-1, as building with switch-curl 7.69.1-2 will not allow users with blanked cal0 to download versions.txt over the internet.
+
 ## Kudos
-A big thank you to Blawar, for maintaining the titledb Repository.
+A big thank you to blawar, for maintaining the titledb Repository.
 Without a nice stream of updated versionlists this wouldn't be feasible.
+
+Another huge thank you to aedalzotto, for both implementing the ability to download versions.txt over the internet and fixing my terrible parsing code.

--- a/include/main.h
+++ b/include/main.h
@@ -5,6 +5,7 @@
 #include <dirent.h>
 #define GetCurrentDir getcwd
 
+#define VERSIONS_URL "https://raw.githubusercontent.com/blawar/titledb/master/versions.txt"
 
 struct MetaData {
 	char TID [17];
@@ -22,5 +23,7 @@ void initLists(NsApplicationRecord**, int*, NsApplicationContentMetaStatus***, i
 void updateMeta(char**, char**, u64);
 Entry* initLocalVerList(void);
 Entry* initExtVerList(void);
+Entry* initWebVerList(void);
+Entry* handleVerList(Entry*, long, char*);
 void checkForUpdates(FILE*, Entry*, Entry*);
 void freeList(Entry*);

--- a/source/handleVerList.c
+++ b/source/handleVerList.c
@@ -1,0 +1,63 @@
+#include "main.h"
+
+Entry *handleVerList(Entry *currExtEntry, long fileSize, char *memVerList)
+{
+	Entry *listHead, *tmp;
+	listHead = currExtEntry;
+
+	/* Create our linked list of versionlist Entries */
+	int parsedExtEntries = 0;
+	long index = 21;
+	while (index < fileSize)
+	{
+		if ((*(memVerList + (index +  13)) != 0) || (*(memVerList + (index + 14)) != 0) || (*(memVerList + (index + 15)) != 0))
+		{
+			tmp = calloc(1, sizeof(Entry));
+			tmp->prev = currExtEntry;
+			currExtEntry->next = tmp;
+			tmp = NULL;
+			currExtEntry = currExtEntry->next;
+
+			/* Parse TID */
+			for (int i = 0; i < 16; i++)
+			{
+				currExtEntry->Data.TID[i] = *(memVerList + (index + i));
+			}
+			currExtEntry->Data.TID[16] = 0;
+			index += 50;
+
+			/* Parse Version */
+			char c = 0;
+			currExtEntry->Data.version = 0;
+			if (*(memVerList + index) != 13)
+			{
+				c = *(memVerList + index);
+				while (c != 13)
+				{
+					currExtEntry->Data.version *= 10;
+					currExtEntry->Data.version += (*(memVerList + index) - 48);
+					index++;
+					c = *(memVerList + index);
+				}
+			}
+			parsedExtEntries++;
+		}
+		else
+		{
+			index += 50;
+			while (*(memVerList + index) != 13)
+				index++;
+		}
+		index += 2;
+		
+		if(index % 250 == 0){
+			consoleClear();
+			printf("Parsing versions.txt...\n\n");
+			printf("Parsed entries: %d", parsedExtEntries);
+			consoleUpdate(NULL);
+		}
+	}
+
+	consoleClear();
+	return listHead;
+}

--- a/source/initExtVerList.c
+++ b/source/initExtVerList.c
@@ -25,7 +25,6 @@ Entry* initExtVerList()
 	/* Have an empty entry at head of list */
 	currExtEntry = calloc(1, sizeof(Entry));
 	
-	// char* selectedTxt = calloc(NAME_MAX, sizeof(char));
 	fseek(verListTxt, 0, SEEK_END);
 	long fileSize = ftell(verListTxt);
 	memVerList = calloc(fileSize, sizeof(char));
@@ -45,7 +44,6 @@ Entry* initExtVerList()
 			if (kDown & KEY_PLUS) return NULL;
 		}
 	}
-	// free(selectedTxt);
 	
 	return handleVerList(currExtEntry, fileSize, memVerList);
 }

--- a/source/initExtVerList.c
+++ b/source/initExtVerList.c
@@ -3,7 +3,7 @@
 Entry* initExtVerList()
 {
 	FILE *verListTxt;
-	Entry *listHead, *currExtEntry, *tmp;
+	Entry *currExtEntry;
 	char *memVerList;
 	
 	verListTxt = fopen("versions.txt", "r");
@@ -24,9 +24,8 @@ Entry* initExtVerList()
 	
 	/* Have an empty entry at head of list */
 	currExtEntry = calloc(1, sizeof(Entry));
-	listHead = currExtEntry;
 	
-	char* selectedTxt = calloc(NAME_MAX, sizeof(char));
+	// char* selectedTxt = calloc(NAME_MAX, sizeof(char));
 	fseek(verListTxt, 0, SEEK_END);
 	long fileSize = ftell(verListTxt);
 	memVerList = calloc(fileSize, sizeof(char));
@@ -46,59 +45,7 @@ Entry* initExtVerList()
 			if (kDown & KEY_PLUS) return NULL;
 		}
 	}
-	free(selectedTxt);
+	// free(selectedTxt);
 	
-	/* Create our linked list of versionlist Entries */
-	int parsedExtEntries = 0;
-	long index = 21;
-	while (index < fileSize)
-	{
-		if ((*(memVerList + (index +  13)) != 0) || (*(memVerList + (index + 14)) != 0) || (*(memVerList + (index + 15)) != 0))
-		{
-			tmp = calloc(1, sizeof(Entry));
-			tmp->prev = currExtEntry;
-			currExtEntry->next = tmp;
-			tmp = NULL;
-			currExtEntry = currExtEntry->next;
-
-			/* Parse TID */
-			for (int i = 0; i < 16; i++)
-			{
-				currExtEntry->Data.TID[i] = *(memVerList + (index + i));
-			}
-			currExtEntry->Data.TID[16] = 0;
-			index += 50;
-
-			/* Parse Version */
-			char c = 0;
-			currExtEntry->Data.version = 0;
-			if (*(memVerList + index) != 13)
-			{
-				c = *(memVerList + index);
-				while (c != 13)
-				{
-					currExtEntry->Data.version *= 10;
-					currExtEntry->Data.version += (*(memVerList + index) - 48);
-					index++;
-					c = *(memVerList + index);
-				}
-			}
-			parsedExtEntries++;
-		}
-		else
-		{
-			index += 50;
-			while (*(memVerList + index) != 13)
-				index++;
-		}
-		index += 2;
-		
-		consoleClear();
-		printf("Parsing versions.txt...\n\n");
-		printf("Parsed entries: %d", parsedExtEntries);
-		consoleUpdate(NULL);
-	}
-
-	consoleClear();
-	return listHead;
+	return handleVerList(currExtEntry, fileSize, memVerList);
 }

--- a/source/initWebVerList.c
+++ b/source/initWebVerList.c
@@ -1,0 +1,102 @@
+#include <curl/curl.h>
+#include "main.h"
+
+struct MemoryStruct {
+	char *memory;
+	size_t size;
+};
+
+static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+	size_t realsize = size * nmemb;
+	struct MemoryStruct *mem = (struct MemoryStruct *)userp;
+
+	char *ptr = realloc(mem->memory, mem->size + realsize + 1);
+	if(ptr == NULL) {
+		/* out of memory! */ 
+		printf("not enough memory (realloc returned NULL)\n");
+		return 0;
+	}
+
+	mem->memory = ptr;
+	memcpy(&(mem->memory[mem->size]), contents, realsize);
+	mem->size += realsize;
+	mem->memory[mem->size] = 0;
+
+	return realsize;
+}
+
+static int xferinfo(
+	void *curl,
+	curl_off_t dltotal,
+	curl_off_t dlnow,
+	curl_off_t ultotal,
+	curl_off_t ulnow
+)
+{
+	static curl_off_t then = -500;
+	curl_off_t now = 0;
+	curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME_T, &now);
+
+	if(now - then >= 250 * 1000){
+		consoleClear();
+		printf("Downloading version.txt...\n");
+		printf("DOWN: %" CURL_FORMAT_CURL_OFF_T " of %" CURL_FORMAT_CURL_OFF_T"\r\n", dlnow, dltotal);
+		consoleUpdate(NULL);
+		then = now;
+	}
+
+	return 0;
+}
+
+Entry* initWebVerList()
+{
+	CURLcode ret = curl_global_init(CURL_GLOBAL_ALL);
+	if(ret == 2){
+		printf("\nThis application was probably built with a newer libcurl.\n");
+		printf("Connections with blanked cal0 will fail.\n");
+		printf("Please downgrade switch-curl to 7.69.1-1 and rebuild\n\n");
+		printf("Falling back to external downloaded file.\n");
+		consoleUpdate(NULL);
+		return NULL;
+	}
+	
+	CURL *curl_handle = curl_easy_init();
+	
+	struct MemoryStruct chunk;
+	chunk.memory = malloc(1);  /* will be grown as needed by the realloc above */ 
+	chunk.size = 0;    /* no data at this point */
+
+	curl_easy_setopt(curl_handle, CURLOPT_URL, VERSIONS_URL);
+	curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 0L);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
+	curl_easy_setopt(curl_handle, CURLOPT_XFERINFOFUNCTION, xferinfo);
+	curl_easy_setopt(curl_handle, CURLOPT_XFERINFODATA, curl_handle);
+	curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 0L);
+
+	ret = curl_easy_perform(curl_handle);
+
+	curl_easy_cleanup(curl_handle);
+	curl_handle = NULL;
+	curl_global_cleanup();
+
+	if(ret != CURLE_OK){
+		printf("\nFailed to download a copy of versions.txt from web source:\n");
+		printf("%s\n\n", VERSIONS_URL);
+		printf("Falling back to external downloaded file.\n");
+		free(chunk.memory);
+		chunk.memory = NULL;
+		return NULL;
+	} else {
+		printf("\nVersion list downloaded with %lu bytes.\n", (unsigned long)chunk.size);
+		consoleUpdate(NULL);
+	}
+
+	Entry *currExtEntry;
+	
+	/* Have an empty entry at head of list */
+	currExtEntry = calloc(1, sizeof(Entry));	
+
+	return handleVerList(currExtEntry, chunk.size, chunk.memory);
+}

--- a/source/initWebVerList.c
+++ b/source/initWebVerList.c
@@ -40,7 +40,7 @@ static int xferinfo(
 
 	if(now - then >= 250 * 1000){
 		consoleClear();
-		printf("Downloading version.txt...\n");
+		printf("Downloading versions.txt...\n");
 		printf("DOWN: %" CURL_FORMAT_CURL_OFF_T " of %" CURL_FORMAT_CURL_OFF_T"\r\n", dlnow, dltotal);
 		consoleUpdate(NULL);
 		then = now;

--- a/source/main.c
+++ b/source/main.c
@@ -8,8 +8,25 @@ int main(int argc, char **argv)
 	localVerList = initLocalVerList();
 	Entry *currLocalEntry = localVerList->next;
 	
+	socketInitializeDefault();
 	Entry *extVerList;
-	extVerList = initExtVerList();
+	extVerList = initWebVerList();
+	socketExit();
+
+	if (extVerList == NULL){
+		printf("\nPress (+) to continue.\n");
+		consoleUpdate(NULL);
+		while (1)
+		{
+			hidScanInput();
+			u64 kDown = hidKeysDown(CONTROLLER_P1_AUTO);
+			if (kDown & KEY_PLUS)
+				break;
+		}
+		consoleClear();
+		extVerList = initExtVerList();
+	}
+	
 	if (extVerList == NULL)
 	{
 		freeList(localVerList);


### PR DESCRIPTION
Hello,

With new version.txt sources, it has been made possible to download it directly from the source.

I have added the function to download it using libcurl. In case of connection failure, it still falls back to old externally downloaded file.
I have also updated the version.txt parser to avoid screen refreshes and improve (a lot, from minutes (?) to few seconds) the performance.

Please beware that the latest switch-curl builds this application fine, but fails in runtime with blanked cal0 users, so, please, build with switch-curl 7.69.1-1